### PR TITLE
fix: Exclude UDP source port 65330 for Azure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,5 @@ FROM mcr.microsoft.com/windows/nanoserver:${OSVERSION}-amd64
 COPY binaries /tools
 USER ContainerAdministrator
 RUN reg import tools\keylight.reg
+RUN ["netsh.exe", "int", "ipv4", "set", "dynamicportrange", "udp", "49152", "16178"]
 USER ContainerUser


### PR DESCRIPTION
Exclude UDP source port 65330 for Azure

Fix: https://github.com/Azure/AKS/issues/2988