### PR TITLE
Deleting diagtrack service to improve pod start times

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,6 @@ FROM mcr.microsoft.com/windows/nanoserver:${OSVERSION}-amd64
 COPY binaries /tools
 USER ContainerAdministrator
 RUN reg import tools\keylight.reg
+# Delete DiagTrack service as it causes CPU spikes and delays pod/container startup times.
+RUN sc.exe delete diagtrack -f
 USER ContainerUser


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

Deleting diagtrack service to improve pod start times